### PR TITLE
TLCALIPER-77 - Update to use authZ with endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 mysqlitedb.db
+viadutoo_example.db

--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ future processing.
 
     ```php
     $proxy = (new MessageProxy())
-        ->setTransportInterface((new CurlTransport()))
+        ->setTransportInterface(
+            (new CurlTransport()) // Recommended transport with cURL, supports Basic Auth and OAuth 1.0
+                ->setAuthZType(CurlTransport::AUTHZ_TYPE_OAUTH1, 'OAuth 1.0 key', 'OAuth 1.0 secret') // Optional authZ
+        )
         ->setEndpointUrl('http://example.com/endpoint')
         ->setTimeoutSeconds(10)
         ->setAutostoreOnSendFailure(true)

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,9 @@
 {
   "name": "umich-its-tl/viadutoo",
   "description": "Viadutoo: caching proxy endpoint for Caliper event data",
-  "keywords": ["viadutoo"],
+  "keywords": [
+    "viadutoo"
+  ],
   "license": "proprietary",
   "authors": [
     {
@@ -11,9 +13,12 @@
     }
   ],
   "require": {
-    "php": ">=5.4"
+    "php": ">=5.4",
+    "eher/oauth": "1.0.7"
   },
   "autoload": {
-    "files": ["lib/Viadutoo/MessageProxy.php"]
+    "files": [
+      "lib/Viadutoo/MessageProxy.php"
+    ]
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,54 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "69ef9e0a1523315c35812f4a05bcb694",
+    "content-hash": "bfbdfca3fda255bb96a027f115c3a146",
+    "packages": [
+        {
+            "name": "eher/oauth",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/EHER/OAuth.git",
+                "reference": "935c1f7709d1c1457de9e250d0e5f29cac06e507"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/EHER/OAuth/zipball/935c1f7709d1c1457de9e250d0e5f29cac06e507",
+                "reference": "935c1f7709d1c1457de9e250d0e5f29cac06e507",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "eher/phpunit": "1.6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Eher\\OAuth": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "OAuth 1 PHP Library",
+            "time": "2012-12-13 23:48:10"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.4"
+    },
+    "platform-dev": []
+}

--- a/lib/Viadutoo/transport/CurlTransport.php
+++ b/lib/Viadutoo/transport/CurlTransport.php
@@ -2,10 +2,21 @@
 require_once 'Viadutoo/transport/BaseTransport.php';
 
 class CurlTransport extends BaseTransport {
+    const
+        AUTHZ_TYPE_BASICAUTH = 'BASICAUTH',
+        AUTHZ_TYPE_OAUTH1 = 'OAUTH1',
+        HTTP_METHOD_POST = 'POST';
+
     /** @var array */
     protected $_lastNativeResultFromSend;
     /** @var string|null */
     private $_caCertPath = null;
+    /** @var string|null */
+    private $_authZType = null;
+    /** @var string|null */
+    private $_authZUserOrKey = null;
+    /** @var string|null */
+    private $_authZPasswordOrSecret = null;
 
     public function __construct() {
         if (!extension_loaded('curl')) {
@@ -66,7 +77,6 @@ class CurlTransport extends BaseTransport {
         curl_setopt_array($client, [
             CURLOPT_POST => true,
             CURLOPT_NOSIGNAL => true, // required for timeouts to work properly
-            CURLOPT_HTTPHEADER => $headerStrings,
             CURLOPT_HEADER => true, // required to return response text
             CURLOPT_RETURNTRANSFER => true, // required to return response text
             CURLOPT_POSTFIELDS => $body,
@@ -80,6 +90,15 @@ class CurlTransport extends BaseTransport {
         if ($timeoutSeconds != null) {
             curl_setopt($client, CURLOPT_TIMEOUT_MS, intval($timeoutSeconds * 1000));
         }
+
+        if ($this->_authZType === self::AUTHZ_TYPE_BASICAUTH) {
+            curl_setopt($client, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+            curl_setopt($client, CURLOPT_USERPWD, $this->_authZUserOrKey . ':' . $this->_authZPasswordOrSecret);
+        } elseif ($this->_authZType === self::AUTHZ_TYPE_OAUTH1) {
+            $headerStrings[] = $this->makeOAuthHeader();
+        }
+
+        curl_setopt($client, CURLOPT_HTTPHEADER, $headerStrings);
 
         $responseText = curl_exec($client);
         $responseInfo = curl_getinfo($client);
@@ -95,5 +114,55 @@ class CurlTransport extends BaseTransport {
         $this->_lastSuccessFromSend = (($responseHttpCode >= 200) && ($responseHttpCode <= 299));
 
         return $this->_lastSuccessFromSend;
+    }
+
+    /**
+     * @return string
+     * @throws \Eher\OAuth\OAuthException
+     */
+    protected function makeOAuthHeader() {
+        $consumer = new Eher\OAuth\Consumer($this->_authZUserOrKey, $this->_authZPasswordOrSecret);
+        $token = null;
+        $httpMethod = self::HTTP_METHOD_POST;
+        $parameters = null;
+
+        $request = Eher\OAuth\Request::from_consumer_and_token(
+            $consumer, $token, $httpMethod, $this->getEndpointUrl(), $parameters
+        );
+        $request->sign_request((new Eher\OAuth\HmacSha1()), $consumer, $token);
+
+        return $request->to_header();
+    }
+
+    /**
+     * @param null|string $authZType Use <u>null</u>, <u>self::AUTHZ_TYPE_BASICAUTH</u>, or
+     *      <u>self::AUTHZ_TYPE_OAUTH1</u>
+     * @param null|string $authZUserOrKey Required only when <u>$authType !== null</u>: username when
+     *      <u>$authType === self::AUTHZ_TYPE_BASICAUTH</u> or key when <u>$authType === self::AUTHZ_TYPE_OAUTH1</u>
+     * @param null|string $authZPasswordOrSecret Required only when <u>$authType !== null</u>: password when
+     *      <u>$authType === self::AUTHZ_TYPE_BASICAUTH</u> or secret when <u>$authType === self::AUTHZ_TYPE_OAUTH1</u>
+     * @return $this
+     * @throws InvalidArgumentException For unknown authorization type or null arguments
+     */
+
+    public function setAuthZType($authZType, $authZUserOrKey = null, $authZPasswordOrSecret = null) {
+        if (is_null($authZType)) {
+            $this->_authZType = null;
+            $this->_authZUserOrKey = null;
+            $this->_authZPasswordOrSecret = null;
+        } elseif (($authZType === self::AUTHZ_TYPE_BASICAUTH) || ($authZType === self::AUTHZ_TYPE_OAUTH1)) {
+            if (is_null($authZUserOrKey) || is_null($authZPasswordOrSecret)) {
+                throw new InvalidArgumentException(__METHOD__ .
+                    ': $authZUserOrKey and $authZPasswordOrSecret must not be null.');
+            } else {
+                $this->_authZType = $authZType;
+                $this->_authZUserOrKey = $authZUserOrKey;
+                $this->_authZPasswordOrSecret = $authZPasswordOrSecret;
+            }
+        } else {
+            throw new InvalidArgumentException(__METHOD__ . ': unknown authorization type, "' . $authZType . '".');
+        }
+
+        return $this;
     }
 }

--- a/public/index.php
+++ b/public/index.php
@@ -73,8 +73,10 @@ error_log("Raw post data:\n${body}");
 error_log('Received ' . strlen($body) . ' bytes');
 
 $proxy = (new MessageProxy())
-    ->setTransportInterface((new CurlTransport()) // Recommended transport with cURL, supports Basic Auth and OAuth 1.0
-        ->setAuthZType(CurlTransport::AUTHZ_TYPE_OAUTH1, 'OAuth 1.0 key', 'OAuth 1.0 secret'))
+    ->setTransportInterface(
+        (new CurlTransport()) // Recommended transport with cURL, supports Basic Auth and OAuth 1.0
+            ->setAuthZType(CurlTransport::AUTHZ_TYPE_OAUTH1, 'OAuth 1.0 key', 'OAuth 1.0 secret') // Optional authZ
+    )
 //    ->setTransportInterface(new PeclHttpTransport()) // Alternate transport with pecl_http, doesn't support authZ
     ->setEndpointUrl('http://lti.tools/caliper/event?key=viadutoo')
     ->setTimeoutSeconds(15)

--- a/public/index.php
+++ b/public/index.php
@@ -73,14 +73,14 @@ error_log("Raw post data:\n${body}");
 error_log('Received ' . strlen($body) . ' bytes');
 
 $proxy = (new MessageProxy())
-//    ->setTransportInterface(new PeclHttpTransport())
-    ->setTransportInterface((new CurlTransport())
+    ->setTransportInterface((new CurlTransport()) // Recommended transport with cURL, supports Basic Auth and OAuth 1.0
         ->setAuthZType(CurlTransport::AUTHZ_TYPE_OAUTH1, 'OAuth 1.0 key', 'OAuth 1.0 secret'))
+//    ->setTransportInterface(new PeclHttpTransport()) // Alternate transport with pecl_http, doesn't support authZ
     ->setEndpointUrl('http://lti.tools/caliper/event?key=viadutoo')
     ->setTimeoutSeconds(15)
     ->setAutostoreOnSendFailure(false)
-    ->setStorageInterface(new SQLite3Storage('viadutoo_example.db'));
-//      ->setStorageInterface(new MysqlStorage('127.0.0.1', 'root', 'root', 'media'));
+    ->setStorageInterface(new SQLite3Storage('viadutoo_example.db')); // Simple storage with SQLite3, good enough for a demo
+//      ->setStorageInterface(new MysqlStorage('127.0.0.1', 'root', 'root', 'dbname')); // Recommended storage with MySQL, more permanent
 
 $success = null;
 try {

--- a/public/index.php
+++ b/public/index.php
@@ -6,6 +6,8 @@
  * and store them via the specified storage interface if the send fails.
  */
 
+require_once '../vendor/autoload.php';
+
 require_once '../lib/Viadutoo/MessageProxy.php';
 require_once 'Viadutoo/transport/PeclHttpTransport.php';
 require_once 'Viadutoo/transport/CurlTransport.php';
@@ -71,15 +73,16 @@ error_log("Raw post data:\n${body}");
 error_log('Received ' . strlen($body) . ' bytes');
 
 $proxy = (new MessageProxy())
-    ->setTransportInterface(new PeclHttpTransport())
-//      ->setTransportInterface(new CurlTransport())
+//    ->setTransportInterface(new PeclHttpTransport())
+    ->setTransportInterface((new CurlTransport())
+        ->setAuthZType(CurlTransport::AUTHZ_TYPE_OAUTH1, 'OAuth 1.0 key', 'OAuth 1.0 secret'))
     ->setEndpointUrl('http://lti.tools/caliper/event?key=viadutoo')
     ->setTimeoutSeconds(15)
     ->setAutostoreOnSendFailure(false)
     ->setStorageInterface(new SQLite3Storage('viadutoo_example.db'));
 //      ->setStorageInterface(new MysqlStorage('127.0.0.1', 'root', 'root', 'media'));
 
-$success = null ;
+$success = null;
 try {
     $success = $proxy
         ->setHeaders($headers)


### PR DESCRIPTION
* JIRA: https://jira.it.umich.edu/browse/TLCALIPER-77
* Implemented in branch: [/lsloan/viadutoo/tree/TLCALIPER-77](/lsloan/viadutoo/tree/TLCALIPER-77)
* Reviewers: @bkirschn, @arwhyte, @pushyamig 
* Due date: 24 May 2016 at 13:00

After authZ features have been added to OpenLRS in TLCALIPER-23, add corresponding features to Viadutoo.  

Both Lecture Capture and Problem Roulette communicate with the endpoint through Viadutoo rather than directly.  Adding authZ support here is a good way to reduce the amount of code to be changed in either of those applications.

---

* Added new dependency, "eher/oauth".
* Added code to support Basic Auth (handled by cURL itself) and OAuth 1.0 (Viadutoo computes the header).
* public/index.php: These changes are similar to those needed in applications to take advantage of Basic Auth or OAuth 1.0. Most importantly, adding a call to `setAuthZType()` for `CurlTransport` when it is used with `setTransportInterface()`.